### PR TITLE
Add etherpad public-enable setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Upcoming:
+* **Enhancement**: add option to disable non-protected 'public' pads.
+
 Ownpad (0.6.5):
 * **Bugfix**: fix UI with Nextcloud 13 (thanks @frissdiegurke).
 * **Enhancement**: enhance settings page.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,7 @@
   <repair-steps>
     <post-migration>
       <step>OCA\Ownpad\Migration\MigrateSettings</step>
+      <step>OCA\Ownpad\Migration\ConfigPublicEnable</step>
     </post-migration>
   </repair-steps>
   <settings>

--- a/js/ownpad.js
+++ b/js/ownpad.js
@@ -75,6 +75,7 @@ OC.Plugins.register('OCA.Files.FileList', OCA.FilesOwnpad);
     FilesOwnpadMenu.prototype = {
 
         _etherpadEnabled: false,
+        _etherpadPublicEnabled: false,
         _etherpadAPIEnabled: false,
         _ethercalcEnabled: false,
 
@@ -86,6 +87,7 @@ OC.Plugins.register('OCA.Files.FileList', OCA.FilesOwnpad);
                     url: OC.generateUrl('/apps/ownpad/ajax/v1.0/getconfig')
                 }).done(function(result) {
                     self._etherpadEnabled = result.data.ownpad_etherpad_enable === "yes";
+                    self._etherpadPublicEnabled = result.data.ownpad_etherpad_public_enable === "yes";
                     self._etherpadAPIEnabled = result.data.ownpad_etherpad_useapi === "yes";
                     self._ethercalcEnabled = result.data.ownpad_ethercalc_enable === "yes";
                     OC.Plugins.register('OCA.Files.NewFileMenu', self);
@@ -98,22 +100,26 @@ OC.Plugins.register('OCA.Files.FileList', OCA.FilesOwnpad);
             var self = this;
 
             if(self._etherpadEnabled === true) {
-                newFileMenu.addMenuEntry({
-                    id: 'etherpad',
-                    displayName: t('ownpad', 'Pad'),
-                    templateName: t('ownpad', 'New pad.pad'),
-                    iconClass: 'icon-filetype-etherpad',
-                    fileType: 'etherpad',
-                    actionHandler: function(filename) {
-                        self._createPad("etherpad", filename);
-                    }
-                });
+                if (self._etherpadPublicEnabled === true || self._etherpadAPIEnabled === false) {
+                    newFileMenu.addMenuEntry({
+                        id: 'etherpad',
+                        displayName: t('ownpad', 'Pad'),
+                        templateName: t('ownpad', 'New pad.pad'),
+                        iconClass: 'icon-filetype-etherpad',
+                        fileType: 'etherpad',
+                        actionHandler: function (filename) {
+                            self._createPad("etherpad", filename);
+                        }
+                    });
+                }
 
                 if(self._etherpadAPIEnabled === true) {
+                    var displayName = self._etherpadPublicEnabled === true ? 'Protected Pad' : 'Pad';
+                    var templateName = self._etherpadPublicEnabled === true ? 'New protected pad.pad' : 'New pad.pad';
                     newFileMenu.addMenuEntry({
                         id: 'etherpad-api',
-                        displayName: t('ownpad', 'Protected Pad'),
-                        templateName: t('ownpad', 'New protected pad.pad'),
+                        displayName: t('ownpad', displayName),
+                        templateName: t('ownpad', templateName),
                         iconClass: 'icon-filetype-etherpad',
                         fileType: 'etherpad',
                         actionHandler: function(filename) {

--- a/lib/Controller/AjaxController.php
+++ b/lib/Controller/AjaxController.php
@@ -39,6 +39,7 @@ class AjaxController extends Controller {
 
         $appConfig = \OC::$server->getConfig();
         $config['ownpad_etherpad_enable'] = $appConfig->getAppValue('ownpad', 'ownpad_etherpad_enable', 'no');
+        $config['ownpad_etherpad_public_enable'] = $appConfig->getAppValue('ownpad', 'ownpad_etherpad_public_enable', 'no');
         $config['ownpad_etherpad_useapi'] = $appConfig->getAppValue('ownpad', 'ownpad_etherpad_useapi', 'no');
         $config['ownpad_ethercalc_enable'] = $appConfig->getAppValue('ownpad', 'ownpad_ethercalc_enable', 'no');
 

--- a/lib/Migration/ConfigPublicEnable.php
+++ b/lib/Migration/ConfigPublicEnable.php
@@ -33,7 +33,7 @@ class ConfigPublicEnable implements IRepairStep {
 
     public function run(IOutput $output) {
         $installedVersion = $this->config->getAppValue('ownpad', 'installed_version', '0.0.0');
-        if(version_compare($installedVersion, '0.6.6', '<')) {
+        if(version_compare($installedVersion, '0.6.6', '<') AND $installedVersion !== '0.0.0') {
             $appConfig = \OC::$server->getConfig();
 
             $enabled = ($appConfig->getAppValue('ownpad', 'ownpad_etherpad_public_enable', '') === '') ? 'yes' : 'no';

--- a/lib/Migration/ConfigPublicEnable.php
+++ b/lib/Migration/ConfigPublicEnable.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Nextcloud - Ownpad
+ *
+ * This file is licensed under the Affero General Public License
+ * version 3 or later. See the COPYING file.
+ *
+ * @author Ole Reglitzki <frissdiegurke@protonmail.com>
+ * @copyright Ole Reglitzki <frissdiegurke@protonmail.com>, 2018
+ */
+
+namespace OCA\Ownpad\Migration;
+
+use OCP\Migration\IRepairStep;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+
+class ConfigPublicEnable implements IRepairStep {
+
+    /** @var IConfig */
+    private $config;
+
+    /**
+     * @param IConfig $config
+     */
+    public function __construct(IConfig $config) {
+        $this->config = $config;
+    }
+
+    public function getName() {
+        return '0.6.6 introduces a new checkbox to enable/disable public pads if protected pads are enabled.';
+    }
+
+    public function run(IOutput $output) {
+        $installedVersion = $this->config->getAppValue('ownpad', 'installed_version', '0.0.0');
+        if(version_compare($installedVersion, '0.6.6', '<')) {
+            $appConfig = \OC::$server->getConfig();
+
+            $enabled = ($appConfig->getAppValue('ownpad', 'ownpad_etherpad_public_enable', '') === '') ? 'yes' : 'no';
+            $appConfig->setAppValue('ownpad', 'ownpad_etherpad_public_enable', $enabled);
+        }
+    }
+
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -49,6 +49,7 @@ class AdminSettings implements ISettings {
             'ownpad_etherpad_enable' => $this->config->getAppValue('ownpad', 'ownpad_etherpad_enable', 'no'),
             'ownpad_etherpad_host' => $this->config->getAppValue('ownpad', 'ownpad_etherpad_host', ''),
             'ownpad_etherpad_useapi' => $this->config->getAppValue('ownpad', 'ownpad_etherpad_useapi', 'no'),
+            'ownpad_etherpad_public_enable' => $this->config->getAppValue('ownpad', 'ownpad_etherpad_public_enable', 'no'),
             'ownpad_etherpad_apikey' => $this->config->getAppValue('ownpad', 'ownpad_etherpad_apikey', ''),
             'ownpad_etherpad_cookie_domain' => $this->config->getAppValue('ownpad', 'ownpad_etherpad_cookie_domain', ''),
             'ownpad_ethercalc_enable' => $this->config->getAppValue('ownpad', 'ownpad_ethercalc_enable', 'no'),

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -41,6 +41,10 @@ style('ownpad', 'settings');
 
         <p id="ownpad_etherpad_useapi_settings" class="double-indent <?php if ($_['ownpad_etherpad_enable'] !== 'yes' || $_['ownpad_etherpad_useapi'] !== 'yes') p('hidden'); ?>">
 
+            <input type="checkbox" name="ownpad_etherpad_public_enable" id="ownpad_etherpad_public_enable" class="checkbox"
+                   value="1" <?php if ($_['ownpad_etherpad_public_enable'] === 'yes') print_unescaped('checked="checked"'); ?> />
+            <label for="ownpad_etherpad_public_enable"><?php p($l->t('Allow “public” pads'));?></label><br/>
+
             <label for="ownpad_etherpad_apikey"><?php p($l->t('Etherpad Apikey')); ?></label><br/>
             <input type="text" name="ownpad_etherpad_apikey" id="ownpad_etherpad_apikey" value="<?php p($_['ownpad_etherpad_apikey']); ?>" /><br/>
 


### PR DESCRIPTION
I like to disable the public pads and only use the (experimental) API for protected pads, thus I need this option.

`Allow “public” pads` would need a french translation thought ;-)