### PR TITLE
ISecureRandom: use generate directly

### DIFF
--- a/lib/Service/OwnpadService.php
+++ b/lib/Service/OwnpadService.php
@@ -17,7 +17,7 @@ class OwnpadService {
 
     public function create($dir, $padname, $type, $protected) {
         // Generate a random pad name
-        $token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(16, \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_UPPER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
+        $token = \OC::$server->getSecureRandom()->generate(16, \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_UPPER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
 
         $l10n = \OC::$server->getL10N('ownpad');
         $l10n_files = \OC::$server->getL10N('files');


### PR DESCRIPTION
getMediumStrengthGenerator is deprecated and will be removed in NC16
nextcloud/server#12907