### PR TITLE
Private pads description update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ example, you’ll have to set the cookie domain to `example.org` within
 the Ownpad settings.
 
 If you want to create *truly* private pads, you have to dedicate an
-Etherpad instance for Nextcloud. You will then configure Etherpad to
+Etherpad instance for Nextcloud **running both with HTTPS**. You will then configure Etherpad to
 restrict pad access via sessions and pad creation via the API.
 For this, you have to adjust your Etherpad configuration file
 (`settings.json`) as following:


### PR DESCRIPTION
Hi,
I just made clear that HTTPS is needed to run Etherpad with Nextcloud and private pads through the API.

I realized that in DisplayController.php line 95, we have setcookie() with the HTTPS only parameter set. I'm running all locally and couldn't figure out why Etherpad couldn't grant me access to pads, It was because the session ID was not being sent.

Thank you for your work! :smile: