### PR TITLE
Add docs section on basic httpd auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ For the snap-distribution that is
 
 ## Create access restricted pads
 
+### HTTP Auth
+
+Basic HTTP auth enabled on the Etherpad webserver is compatible with 
+Ownpad. If this is used then the user will simply be prompted to enter 
+login credentials by their browser when they try to access a pad from 
+within Nextcloud.
+
+### Etherpad-managed auth
+
 Ownpad supports communication with the Etherpad API for access
 restriction (so called *protected pads*). This support is considered
 **experimental** due to work in progress; some features are still


### PR DESCRIPTION
Add info about using http auth as a simpler (and perhaps more reliable) auth option than using the etherpad API.