### PR TITLE
Fix ethercalc in nextcloud dark mode

### DIFF
--- a/js/ownpad.js
+++ b/js/ownpad.js
@@ -28,7 +28,7 @@
 
             var viewer = OC.generateUrl('/apps/ownpad/?file={file}&dir={dir}', {file: fileName, dir: dirName});
 
-            $iframe = $('<iframe id="ownpad" style="width:100%;background-color:white;height:100%;display:block;position:absolute;top:0;z-index:999;" src="'+viewer+'"/>');
+            $iframe = $('<iframe id="ownpad" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:999;background-color:white;" src="'+viewer+'"/>');
 
             FileList.setViewerMode(true);
 

--- a/js/ownpad.js
+++ b/js/ownpad.js
@@ -28,7 +28,7 @@
 
             var viewer = OC.generateUrl('/apps/ownpad/?file={file}&dir={dir}', {file: fileName, dir: dirName});
 
-            $iframe = $('<iframe id="ownpad" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:999;" src="'+viewer+'"/>');
+            $iframe = $('<iframe id="ownpad" style="width:100%;background-color:white;height:100%;display:block;position:absolute;top:0;z-index:999;" src="'+viewer+'"/>');
 
             FileList.setViewerMode(true);
 


### PR DESCRIPTION
This is a quick fix to force a white background on the iframe in which EtherCalc is loaded, so that EtherCalc remains usable if NextCloud is used with dark mode.