### PR TITLE
Make application compatible with PHP7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pad name can’t be longer than 50 chars
+
 ## 0.9.4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Make code compatible with PHP7.4
 - Pad name can’t be longer than 50 chars
 
 ## 0.9.4

--- a/lib/Listeners/CSPListener.php
+++ b/lib/Listeners/CSPListener.php
@@ -22,7 +22,7 @@ class CSPListener implements IEventListener {
 	private $config;
 
 	public function __construct(
-		IConfig $config,
+		IConfig $config
 	) {
 		$this->config = $config;
 	}

--- a/lib/Service/OwnpadService.php
+++ b/lib/Service/OwnpadService.php
@@ -29,7 +29,7 @@ class OwnpadService {
 
 	public function __construct(
 		IConfig $config,
-		IUserSession $userSession,
+		IUserSession $userSession
 	) {
 		$this->config = $config;
 		$this->userSession = $userSession;

--- a/lib/Service/OwnpadService.php
+++ b/lib/Service/OwnpadService.php
@@ -44,7 +44,7 @@ class OwnpadService {
 
 	public function create($dir, $padname, $type, $protected) {
 		// Generate a random pad name
-		$token = \OC::$server->getSecureRandom()->generate(rand(32, 64), \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
+		$token = \OC::$server->getSecureRandom()->generate(rand(32, 50), \OCP\Security\ISecureRandom::CHAR_LOWER.\OCP\Security\ISecureRandom::CHAR_DIGITS);
 
 		$l10n = \OC::$server->getL10N('ownpad');
 		$l10n_files = \OC::$server->getL10N('files');


### PR DESCRIPTION
### Fixed

- Make code compatible with PHP7.4
- Pad name can’t be longer than 50 chars