### PR TITLE
fix: Add resource to data sent when get Bearer Token

### DIFF
--- a/lib/Service/OwnpadService.php
+++ b/lib/Service/OwnpadService.php
@@ -313,6 +313,7 @@ class OwnpadService {
 	private function getBearerToken() {
 		$oidcUrl = $this->eplHost . "/oidc/token";
 		$data = [
+			"resource" => $this->eplHost . "/oidc/resource",
 			"grant_type" => "client_credentials",
 			"client_id" => $this->eplClientId,
 			"client_secret" => $this->eplClientSecret,


### PR DESCRIPTION
Latest version of Etherpad (at least 2.4.0 and 2.5.0) trigger the error 'resource indicator must be an absolute URI'.
This change add the required resource value (absolute uri +  /oidc/resource)
